### PR TITLE
Two small modifications so to integrate with existing projects

### DIFF
--- a/JSLikeBasePromise.hpp
+++ b/JSLikeBasePromise.hpp
@@ -104,10 +104,7 @@ namespace JSLike {
     T &value() {
       PromiseState<T>* castState = dynamic_cast<PromiseState<T> *>(this);
       if (!castState) {
-        string err("bad cast from BasePromiseState to PromiseState<");
-        err += typeid(T).name();
-        err += ">";
-        throw bad_cast::__construct_from_string_literal(err.c_str());
+        throw bad_cast();
       }
       return castState->value();
     }
@@ -117,10 +114,7 @@ namespace JSLike {
     void resolve(T& value) {
       PromiseState<T>* castState = dynamic_cast<PromiseState<T> *>(this);
       if (!castState) {
-        string err("bad cast from BasePromiseState to PromiseState<");
-        err += typeid(T).name();
-        err += ">";
-        throw bad_cast::__construct_from_string_literal(err.c_str());
+        throw bad_cast();
       }
       castState->resolve(value);
     }
@@ -137,10 +131,7 @@ namespace JSLike {
     void resolve(T && value) {
       PromiseState<T>* castState = dynamic_cast<PromiseState<T> *>(this);
       if (!castState) {
-        string err("bad cast from BasePromiseState to PromiseState<");
-        err += typeid(T).name();
-        err += ">";
-        throw bad_cast::__construct_from_string_literal(err.c_str());
+        throw bad_cast();
       }
       castState->resolve(forward<T>(value));
     }

--- a/JSLikeBasePromise.hpp
+++ b/JSLikeBasePromise.hpp
@@ -107,7 +107,7 @@ namespace JSLike {
         string err("bad cast from BasePromiseState to PromiseState<");
         err += typeid(T).name();
         err += ">";
-        throw bad_cast::__construct_from_string_literal(err.c_str());
+        throw logic_error(err.c_str());
       }
       return castState->value();
     }
@@ -120,7 +120,7 @@ namespace JSLike {
         string err("bad cast from BasePromiseState to PromiseState<");
         err += typeid(T).name();
         err += ">";
-        throw bad_cast::__construct_from_string_literal(err.c_str());
+        throw logic_error(err.c_str());
       }
       castState->resolve(value);
     }
@@ -140,7 +140,7 @@ namespace JSLike {
         string err("bad cast from BasePromiseState to PromiseState<");
         err += typeid(T).name();
         err += ">";
-        throw bad_cast::__construct_from_string_literal(err.c_str());
+        throw logic_error(err.c_str());
       }
       castState->resolve(forward<T>(value));
     }

--- a/JSLikeBasePromise.hpp
+++ b/JSLikeBasePromise.hpp
@@ -104,7 +104,10 @@ namespace JSLike {
     T &value() {
       PromiseState<T>* castState = dynamic_cast<PromiseState<T> *>(this);
       if (!castState) {
-        throw bad_cast();
+        string err("bad cast from BasePromiseState to PromiseState<");
+        err += typeid(T).name();
+        err += ">";
+        throw bad_cast::__construct_from_string_literal(err.c_str());
       }
       return castState->value();
     }
@@ -114,7 +117,10 @@ namespace JSLike {
     void resolve(T& value) {
       PromiseState<T>* castState = dynamic_cast<PromiseState<T> *>(this);
       if (!castState) {
-        throw bad_cast();
+        string err("bad cast from BasePromiseState to PromiseState<");
+        err += typeid(T).name();
+        err += ">";
+        throw bad_cast::__construct_from_string_literal(err.c_str());
       }
       castState->resolve(value);
     }
@@ -131,7 +137,10 @@ namespace JSLike {
     void resolve(T && value) {
       PromiseState<T>* castState = dynamic_cast<PromiseState<T> *>(this);
       if (!castState) {
-        throw bad_cast();
+        string err("bad cast from BasePromiseState to PromiseState<");
+        err += typeid(T).name();
+        err += ">";
+        throw bad_cast::__construct_from_string_literal(err.c_str());
       }
       castState->resolve(forward<T>(value));
     }

--- a/JSLikeBasePromise.hpp
+++ b/JSLikeBasePromise.hpp
@@ -6,9 +6,9 @@
 #include <functional>
 #include <exception>
 
-using namespace std;
-
 namespace JSLike {
+
+  using namespace std;
 
   // Forward declarations needed to declare "friendships" among structs.
   struct BasePromise;

--- a/JSLikePromise.hpp
+++ b/JSLikePromise.hpp
@@ -9,9 +9,9 @@
 
 #include "JSLikeBasePromise.hpp"
 
-using namespace std;
-
 namespace JSLike {
+
+  using namespace std;
 
   // Forward declarations needed to declare "friendships" among structs.
   template<typename T> struct Promise;

--- a/JSLikePromiseAll.hpp
+++ b/JSLikePromiseAll.hpp
@@ -10,9 +10,10 @@
 #include "JSLikePromise.hpp"
 #include "JSLikeBasePromise.hpp"
 
-using namespace std;
-
 namespace JSLike {
+
+  using namespace std;
+
   struct PromiseAllState : public PromiseState<vector<shared_ptr<BasePromiseState>>> {
     PromiseAllState() : m_nUnresolved(-1) {}
 

--- a/JSLikePromiseAny.hpp
+++ b/JSLikePromiseAny.hpp
@@ -12,9 +12,10 @@
 #include "JSLikePromise.hpp"
 #include "JSLikeBasePromise.hpp"
 
-using namespace std;
-
 namespace JSLike {
+
+  using namespace std;
+
   struct PromiseAnyState : public PromiseState<shared_ptr<BasePromiseState>> {
     PromiseAnyState() = default;
 


### PR DESCRIPTION
In order to use this code in my project, I changed two things :

1. moved the "use namespace std" below the "namespace JSLike" scope

2. my compiler did not know bad_cast::__construct_from_string_literal so I replaced it with an undocumented bad_cast.